### PR TITLE
Resolve subset of compiler warnings reported by clang on OSX.

### DIFF
--- a/Make.osx-cocoa
+++ b/Make.osx-cocoa
@@ -3,12 +3,13 @@ PTHREAD=	# for Mac
 AR=ar
 AS=as
 RANLIB=ranlib
-CC=gcc
-CFLAGS=-Wall -Wno-missing-braces -ggdb -I$(ROOT) -I$(ROOT)/include -I$(ROOT)/kern -c -D_THREAD_SAFE $(PTHREAD) -O2
+CC=clang
+ANALYZE=--analyze -Xanalyzer -analyzer-output=html -o html-dir
+CFLAGS=-Wall -Wno-gnu-designator -Wno-missing-braces -g -I$(ROOT) -I$(ROOT)/include -I$(ROOT)/kern -c -D_THREAD_SAFE $(PTHREAD) -O2
 O=o
 OS=posix
 GUI=cocoa
-LDADD=-ggdb -framework AppKit -framework OpenGL
+LDADD=-g -framework AppKit -framework OpenGL
 LDFLAGS=$(PTHREAD)
 TARG=drawterm
 AUDIO=none

--- a/gui-cocoa/screen.m
+++ b/gui-cocoa/screen.m
@@ -219,7 +219,7 @@ mainproc(void *aux)
 - (void) otherMouseDown:(NSEvent*)event;
 - (void) otherMouseDragged:(NSEvent*)event;
 - (void) otherMouseUp:(NSEvent*)event;
-- (void) scrollWheel:(NSEvent*)event;                                                                                                                                                                                                                                                                                                                                                                                                   
+- (void) scrollWheel:(NSEvent*)event;
 - (BOOL) acceptsFirstResponder;
 - (void) reshape;
 - (BOOL) acceptsMouseMovedEvents;
@@ -423,6 +423,7 @@ evkey(NSEvent *event)
 }
 
 - (void) reshape {
+	[super reshape];
 	winsize = self.frame.size;
 	NSOpenGLContext *ctxt = [NSOpenGLContext currentContext];
 	[[myview openGLContext] makeCurrentContext];

--- a/kern/devcmd.c
+++ b/kern/devcmd.c
@@ -570,7 +570,7 @@ cmdwstat(Chan *c, uchar *dp, int n)
 			error(Eperm);
 		if(!emptystr(d->uid))
 			kstrdup(&cv->owner, d->uid);
-		if(d->mode != ~0UL)
+		if(d->mode != (p9_ulong)~0UL)
 			cv->perm = d->mode & 0777;
 		poperror();
 		free(d);

--- a/kern/devdraw.c
+++ b/kern/devdraw.c
@@ -624,7 +624,7 @@ drawfreedscreen(DScreen *this)
 		dscreen = this->next;
 		goto Found;
 	}
-	while(next = ds->next){	/* assign = */
+	while((next = ds->next)){	/* assign = */
 		if(next == this){
 			ds->next = this->next;
 			goto Found;
@@ -697,7 +697,7 @@ drawuninstallscreen(Client *client, CScreen *this)
 		free(this);
 		return;
 	}
-	while(next = cs->next){	/* assign = */
+	while((next = cs->next)){	/* assign = */
 		if(next == this){
 			cs->next = this->next;
 			drawfreedscreen(this->dscreen);
@@ -721,7 +721,7 @@ drawuninstall(Client *client, int id)
 		drawfreedimage(d);
 		return;
 	}
-	while(next = d->next){	/* assign = */
+	while((next = d->next)){	/* assign = */
 		if(next->id == id){
 			d->next = next->next;
 			drawfreedimage(next);
@@ -1097,7 +1097,7 @@ drawclose(Chan *c)
 	if(QID(c->qid) == Qctl)
 		cl->busy = 0;
 	if((c->flag&COPEN) && (decref(&cl->r)==0)){
-		while(r = cl->refresh){	/* assign = */
+		while((r = cl->refresh)){	/* assign = */
 			cl->refresh = r->next;
 			free(r);
 		}
@@ -1343,10 +1343,10 @@ drawcoord(uchar *p, uchar *maxp, int oldx, int *newx)
 		x |= *p++ << 7;
 		x |= *p++ << 15;
 		if(x & (1<<22))
-			x |= ~0<<23;
+			x |= ~0U<<23;
 	}else{
 		if(b & 0x40)
-			x |= ~0<<7;
+			x |= ~0U<<7;
 		x += oldx;
 	}
 	*newx = x;
@@ -1358,10 +1358,9 @@ printmesg(char *fmt, uchar *a, int plsprnt)
 {
 	char buf[256];
 	char *p, *q;
-	int s;
+	int dbg = 0;
 
-	if(1|| plsprnt==0){
-		USED(s);
+	if(!dbg || plsprnt==0){
 		return;
 	}
 	q = buf;
@@ -1427,7 +1426,6 @@ drawmesg(Client *client, void *av, int n)
 	fmt = nil;
 	if(waserror()){
 		if(fmt) printmesg(fmt, a, 1);
-	/*	iprint("error: %s\n", up->errstr);	*/
 		nexterror();
 	}
 	while((n-=m) > 0){
@@ -2055,7 +2053,6 @@ drawmesg(Client *client, void *av, int n)
 		case 'y':
 		case 'Y':
 			printmesg(fmt="LR", a, 0);
-		//	iprint("load %c\n", *a);
 			m = 1+4+4*4;
 			if(n < m)
 				error(Eshortdraw);

--- a/libauth/attr.c
+++ b/libauth/attr.c
@@ -6,7 +6,6 @@ int
 _attrfmt(Fmt *fmt)
 {
 	Attr *a;
-	int first = 1;
 
 	for(a=va_arg(fmt->args, Attr*); a != nil; a=a->next){
 		if(a->name == nil)
@@ -15,14 +14,13 @@ _attrfmt(Fmt *fmt)
 		default:
 			continue;
 		case AttrQuery:
-			fmtprint(fmt, first+" %q?", a->name);
+			fmtprint(fmt, " %q?", a->name);
 			break;
 		case AttrNameval:
 		case AttrDefault:
-			fmtprint(fmt, first+" %q=%q", a->name, a->val);
+			fmtprint(fmt, " %q=%q", a->name, a->val);
 			break;
 		}
-		first = 0;
 	}
 	return 0;
 }

--- a/libc/runestrchr.c
+++ b/libc/runestrchr.c
@@ -13,7 +13,7 @@ runestrchr(Rune *s, Rune c)
 		return s-1;
 	}
 
-	while(c1 = *s++)
+	while((c1 = *s++))
 		if(c1 == c0)
 			return s-1;
 	return 0;

--- a/libc/strtod.c
+++ b/libc/strtod.c
@@ -525,7 +525,7 @@ xcmp(char *a, char *b)
 {
 	int c1, c2;
 
-	while(c1 = *b++) {
+	while((c1 = *b++)) {
 		c2 = *a++;
 		if(isupper(c2))
 			c2 = tolower(c2);


### PR DESCRIPTION
This pull requests resolves some of the compiler warnings emitted while trying on a somewhat recent OSX development tool chain.

It also adds some options to the `Make.osx-cocoa` file that configure clangs static analyser (disabled by default).