### PR TITLE
drawterm: fix off-by-one write and out-of-bound read in libmemraw/draw.c

### DIFF
--- a/libmemdraw/draw.c
+++ b/libmemdraw/draw.c
@@ -1476,7 +1476,7 @@ readbyte(Param *p, uchar *buf, int y)
 {
 	Buffer b;
 	Memimage *img;
-	int dx, isgrey, convgrey, alphaonly, copyalpha, i, nb;
+	int dx, isgrey, convgrey, alphaonly, copyalpha, i, j, nb;
 	uchar *begin, *end, *r, *w, *rrepl, *grepl, *brepl, *arepl, *krepl;
 	uchar ured, ugrn, ublu;
 	ulong u;
@@ -1526,7 +1526,8 @@ readbyte(Param *p, uchar *buf, int y)
 	krepl = replbit[img->nbits[CGrey]];
 
 	for(i=0; i<dx; i++){
-		u = r[0] | (r[1]<<8) | (r[2]<<16) | (r[3]<<24);
+		for(j = 0, u = 0 ; j < 4 && r+j < end ; j++)
+			u |= r[j] << (8*j);
 		if(copyalpha) {
 			*w++ = arepl[(u>>img->shift[CAlpha]) & img->mask[CAlpha]];
 		}
@@ -2136,8 +2137,8 @@ memoptdraw(Memdrawparam *par)
 						*dp ^= (v ^ *dp) & lm;
 						dp++;
 					}
-					memset(dp, v, dx);
-					dp += dx;
+					memset(dp, v, dx-1);
+					dp += dx-1;
 					*dp ^= (v ^ *dp) & rm;
 				}
 			}


### PR DESCRIPTION
To reproduce the errors consistently with enough information to trace
down the root cuase, compile drawterm with the following options:

	CFDEBUG=-fno-omit-frame-pointer -fsanitize=address -O0
	CFLAGS=$(CFDEBUG) -Wall -Wno-gnu-designator -Wno-missing-braces -g  -I$(ROOT) -I$(ROOT)/include -I$(ROOT)/kern -c -D_THREAD_SAFE $(PTHREAD)

	LDDEBUG=-fsanitize=address
	LDADD=-g -framework AppKit -framework OpenGL $(LDDEBUG)

These options use ASAN in combination with clang/llvm and ensure we
get a proper stack trace pointing to the guilty statement.  Without
these options the stack trace you get is useless.

In libmemdraw/draw.c:/^memoptdraw an off by one write causes a
SEGFAULT.  The fault typically occurres in complex drawterm sessions
(i.e.  you have to stress the draw routines).  The best way to
reproduce it was to run two instances of netsurf, catclock, and doom.

Running a complex drawterm session (where drawterm was compiled with
above options) will then crash as follows:

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Application Specific Information:
=================================================================
==81878==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61a0000b210c at pc 0x0001084224fb bp 0x70000d5065b0 sp 0x70000d5065a8
READ of size 1 at 0x61a0000b210c thread T20

SUMMARY: AddressSanitizer: heap-buffer-overflow draw.c:2141 in memoptdraw
Shadow bytes around the buggy address:
  0x1c34000163d0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c34000163e0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c34000163f0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3400016400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3400016410: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x1c3400016420: 00[04]fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400016430: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400016440: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400016450: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400016460: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3400016470: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa

The following diff snippet shows the problematic code together with
its fix:

```c
@@ -2136,8 +2137,8 @@ memoptdraw(Memdrawparam *par)
 						*dp ^= (v ^ *dp) & lm;
 						dp++;
 					}
-					memset(dp, v, dx);
-					dp += dx;
+					memset(dp, v, dx-1);
+					dp += dx-1;
 					*dp ^= (v ^ *dp) & rm;
 				}
 			}
```

The actual SEFGAULT occurrs at the statement:

• `*dp ^= (v ^ *dp) & rm;`

because in certain conditions it was writing out-of-bounds.  That was
identified by initially adding asserts(...) to narrow down the root
cause.

In libmemdraw/draw.c:/^readbyte an out of bound read would read garbage
data and cause execution with ASAN to terminate with the following error:

Application Specific Information:
=================================================================
==83236==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61d00003798c at pc 0x00010d4ab58c bp 0x70000ad2e840 sp 0x70000ad2e838
READ of size 1 at 0x61d00003798c thread T15
...
SUMMARY: AddressSanitizer: heap-buffer-overflow draw.c:1529 in readbyte
Shadow bytes around the buggy address:
  0x1c3a00006ee0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3a00006ef0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3a00006f00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3a00006f10: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3a00006f20: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x1c3a00006f30: 00[04]fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3a00006f40: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x1c3a00006f50: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3a00006f60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3a00006f70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1c3a00006f80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

The problematic statement is:

• `u = r[0] | (r[1]<<8) | (r[2]<<16) | (r[3]<<24);`

The variable `r` is a uchar* pointer and we are, in certain
conditions, reading more memory than we are supposed to in the above
statement.

We have to be careful that at the index where we dereference `r` we
are not reading beyond the end of a buffer.  The fix below adds a
bounds check that never reads beyond bounds:

```c
@@ -1526,7 +1526,8 @@ readbyte(Param *p, uchar *buf, int y)
 	krepl = replbit[img->nbits[CGrey]];

 	for(i=0; i<dx; i++){
-		u = r[0] | (r[1]<<8) | (r[2]<<16) | (r[3]<<24);
+		for(j = 0, u = 0 ; j < 4 && r+j < end ; j++)
+		  u |= r[j] << (8*j);
 		if(copyalpha) {
 			*w++ = arepl[(u>>img->shift[CAlpha]) & img->mask[CAlpha]];
 		}
```